### PR TITLE
Add certificate chains for end-entity certs

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -27,6 +27,7 @@ java {
     withSourcesJar()
 }
 
+// Compatibility with JDK8.
 compileJava {
     options.release = 8
 }


### PR DESCRIPTION
Certificate chains are now returned together with end-entity certificates (`CA:false`) by following methods: `getCertificates()`, `getCertificatesAsPem()`, `writeCertificatesAsPem()`. Certificate chain contain issuing CA certificates up to but not including root CA certificate.

Fixes #2.