### PR TITLE
Return chains for sub CAs too

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Certy
 
 ![](https://github.com/tsaarni/java-certy/workflows/unit-tests/badge.svg)
+[![Maven Central](https://img.shields.io/maven-central/v/fi.protonode/certy)](https://search.maven.org/search?q=g:fi.protonode%20AND%20a:certy)
 
 ## Description
 

--- a/lib/src/main/java/fi/protonode/certy/Credential.java
+++ b/lib/src/main/java/fi/protonode/certy/Credential.java
@@ -415,9 +415,7 @@ public class Credential {
     }
 
     /**
-     * Returns PEM bundle containing X509 certificate and its chain.
-     * If the credential is end-entity (CA:false) then also chain certificates
-     * up to (but not including) root CA are returned in the bundle.
+     * Returns PEM bundle containing X509 certificate and its chain (if any).
      *
      * @return String containing PEM bundle.
      */
@@ -475,9 +473,7 @@ public class Credential {
     }
 
     /**
-     * Writes PEM bundle containing X509 certificate and its chain.
-     * If the credential is end-entity (CA:false) then also chain certificates
-     * up to (but not including) root CA are written in the bundle.
+     * Writes PEM bundle containing X509 certificate and its chain (if any).
      *
      * @param out Path to write the PEM file to.
      * @return The Credential itself.
@@ -530,10 +526,9 @@ public class Credential {
     }
 
     /**
-     * Returns certificate(s).
-     * If the credential is end-entity (CA:false) then also chain certificates up to (but not including) root CA are returned.
+     * Returns certificate and its chain (if any).
      *
-     * @return Array of certificates. Always holds just single certificate.
+     * @return Array of certificates.
      */
     public Certificate[] getCertificates()
             throws CertificateException, NoSuchAlgorithmException {
@@ -690,14 +685,13 @@ public class Credential {
         // Add the certificate itself.
         chain.add(certificate);
 
-        // If not CA then add chain certificates as well.
-        if (Boolean.FALSE.equals(isCa)) {
-            Credential parent = issuer;
-            while (parent != null && parent.issuer != null) {
-                chain.add(parent.certificate);
-                parent = parent.issuer;
-            }
+        // Add chain.
+        Credential parent = issuer;
+        while (parent != null && parent.issuer != null) {
+            chain.add(parent.certificate);
+            parent = parent.issuer;
         }
+
         return chain.toArray(new Certificate[0]);
     }
 }

--- a/lib/src/test/java/fi/protonode/certy/TestCredential.java
+++ b/lib/src/test/java/fi/protonode/certy/TestCredential.java
@@ -330,17 +330,17 @@ public class TestCredential {
         Credential subSubCa = new Credential().subject("CN=sub-sub-ca").ca(true).issuer(subCa);
         Credential cred = new Credential().subject("CN=end-entity").issuer(subSubCa);
 
-        // Chain contains all sub CAs.
+        // Chain contains all sub CAs but not the root CA.
         Certificate[] chain = cred.getCertificates();
         assertEquals(3, chain.length);
         assertEquals(cred.getCertificate(), chain[0]);
         assertEquals(subSubCa.getCertificate(), chain[1]);
         assertEquals(subCa.getCertificate(), chain[2]);
 
-        // For CA certificates we do not include chain.
         chain = subSubCa.getCertificates();
-        assertEquals(1, chain.length);
+        assertEquals(2, chain.length);
         assertEquals(subSubCa.getCertificate(), chain[0]);
+        assertEquals(subCa.getCertificate(), chain[1]);
 
         chain = subCa.getCertificates();
         assertEquals(1, chain.length);


### PR DESCRIPTION
Return chains for certificates with `CA:false` and `CA:true` for consistensy, when calling the _plural_ methods like `getCertificates()`, since to get the certificate itself, without chain, there is `getCertificate()`.