### PR TITLE
Add method to get chain as X509Certificate[]

### DIFF
--- a/lib/src/main/java/fi/protonode/certy/Credential.java
+++ b/lib/src/main/java/fi/protonode/certy/Credential.java
@@ -571,6 +571,17 @@ public class Credential {
     }
 
     /**
+     * Returns certificate and its chain (if any).
+     *
+     * @return Array of certificates as {@code X509Certificate}.
+     */
+    public X509Certificate[] getX509Certificates() throws CertificateException, NoSuchAlgorithmException {
+        ensureGenerated();
+
+        return Arrays.stream(getChain()).map(c -> (X509Certificate) c).toArray(X509Certificate[]::new);
+    }
+
+    /**
      * Returns private key.
      *
      * @return Private key.

--- a/lib/src/test/java/fi/protonode/certy/TestCredential.java
+++ b/lib/src/test/java/fi/protonode/certy/TestCredential.java
@@ -356,6 +356,12 @@ public class TestCredential {
         chain = rootCa.getCertificates();
         assertEquals(1, chain.length);
         assertEquals(rootCa.getCertificate(), chain[0]);
+
+        X509Certificate[] x509chain = cred.getX509Certificates();
+        assertEquals(3, x509chain.length);
+        assertEquals(cred.getX509Certificate(), x509chain[0]);
+        assertEquals(subSubCa.getX509Certificate(), x509chain[1]);
+        assertEquals(subCa.getX509Certificate(), x509chain[2]);
     }
 
     @Test


### PR DESCRIPTION
This PR adds a new method to retrieve chain as `X509Certificate[]`.

Fixes #29 
