### PR TITLE
Run build and tests with multiple JDK releases

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -7,17 +7,22 @@ on:
     branches: [ main ]
 
 jobs:
-  gradle:
+  build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ '11', '17', '21' ]
+    name: Java ${{ matrix.Java }}
+
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-java@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
       with:
         distribution: temurin
-        java-version: 17
+        java-version: ${{ matrix.java }}
 
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/actions/setup-gradle@v4
 
     - name: Execute Gradle build
       run: ./gradlew build

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -33,7 +33,23 @@ java {
 }
 
 compileJava {
-    options.release = 8
+    // Release option was added in JDK 9.
+    if (JavaVersion.current().isJava9Compatible()) {
+        options.release = 8
+    } else {
+        sourceCompatibility = '1.8'
+        targetCompatibility = '1.8'
+    }
+}
+
+sourceSets {
+    test {
+        java {
+            if (JavaVersion.current() < JavaVersion.VERSION_15) {
+                exclude '**/TestCredentialJdk15.java'
+            }
+        }
+    }
 }
 
 publishing {

--- a/lib/src/test/java/fi/protonode/certy/TestCredentialJdk15.java
+++ b/lib/src/test/java/fi/protonode/certy/TestCredentialJdk15.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Certy Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fi.protonode.certy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.security.cert.X509Certificate;
+import java.security.interfaces.EdECPublicKey;
+
+import org.junit.jupiter.api.Test;
+
+import fi.protonode.certy.Credential.KeyType;
+
+/**
+ * Test cases for Credential class using JDK 15 and later.
+ */
+class TestCredentialJdk15 {
+
+    @Test
+    void testEd25519Certificate() throws Exception {
+        Credential cred = new Credential().subject("CN=joe")
+                .keyType(KeyType.ED25519);
+        X509Certificate cert = cred.getX509Certificate();
+        assertNotNull(cert);
+        EdECPublicKey key = (EdECPublicKey) cert.getPublicKey();
+        assertEquals("Ed25519", key.getAlgorithm());
+    }
+
+    @Test
+    void testInvalidKeySize() {
+        Credential cred3 = new Credential().subject("CN=joe").keyType(KeyType.ED25519).keySize(1);
+        assertThrows(IllegalArgumentException.class, () -> cred3.getX509Certificate());
+    }
+
+}

--- a/lib/src/test/java/fi/protonode/certy/TestCredentialJdk8.java
+++ b/lib/src/test/java/fi/protonode/certy/TestCredentialJdk8.java
@@ -49,7 +49,6 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.security.interfaces.ECPublicKey;
-import java.security.interfaces.EdECPublicKey;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.ECParameterSpec;
 import java.security.spec.InvalidKeySpecException;
@@ -60,7 +59,10 @@ import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Date;
 
-class TestCredential {
+/**
+ * Test cases for Credential class using JDK 1.8 and later.
+ */
+class TestCredentialJdk8 {
 
     @Test
     void testSubjectName() throws Exception {
@@ -113,16 +115,6 @@ class TestCredential {
         expectKey(cred.getX509Certificate(), "RSA", 2048);
         cred.keySize(4096).generate();
         expectKey(cred.getX509Certificate(), "RSA", 4096);
-    }
-
-    @Test
-    void testEd25519Certificate() throws Exception {
-        Credential cred = new Credential().subject("CN=joe")
-                .keyType(KeyType.ED25519);
-        X509Certificate cert = cred.getX509Certificate();
-        assertNotNull(cert);
-        EdECPublicKey key = (EdECPublicKey) cert.getPublicKey();
-        assertEquals("Ed25519", key.getAlgorithm());
     }
 
     @Test
@@ -266,9 +258,6 @@ class TestCredential {
 
         Credential cred2 = new Credential().subject("CN=joe").keyType(KeyType.RSA).keySize(1);
         assertThrows(IllegalArgumentException.class, () -> cred2.getX509Certificate());
-
-        Credential cred3 = new Credential().subject("CN=joe").keyType(KeyType.ED25519).keySize(1);
-        assertThrows(IllegalArgumentException.class, () -> cred3.getX509Certificate());
     }
 
     @Test
@@ -423,10 +412,8 @@ class TestCredential {
         assertNotNull(dps);
 
         DistributionPointName expected = new DistributionPointName(
-            new GeneralNames(
-                new GeneralName(GeneralName.uniformResourceIdentifier, "http://example.com/crl.pem")
-            )
-        );
+                new GeneralNames(
+                        new GeneralName(GeneralName.uniformResourceIdentifier, "http://example.com/crl.pem")));
 
         assertArrayEquals(new DistributionPoint[] { new DistributionPoint(expected, null, null) }, dps);
     }


### PR DESCRIPTION
To ensure compatibility with JDK8, run tests using LTS versions JDK8, JDK11, and JDK21. 

The main part of the code is in Java 8, but some tests use features from newer versions (such as ED25519). Make these tests conditional by compiling them only with the appropriate JDK.