### PR TITLE
Set minimum JDK version back to 8

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -32,10 +32,8 @@ java {
     withSourcesJar()
 }
 
-// Compatibility with JDK15.
-// - Ed25519 was added in JDK15.
 compileJava {
-    options.release = 15
+    options.release = 8
 }
 
 publishing {

--- a/lib/src/main/java/fi/protonode/certy/Credential.java
+++ b/lib/src/main/java/fi/protonode/certy/Credential.java
@@ -72,8 +72,17 @@ public class Credential {
 
     /** Key type values for {@link #keyType}. */
     public enum KeyType {
+        /**
+         * EC key type.
+         */
         EC,
+        /**
+         * RSA key type.
+         */
         RSA,
+        /**
+         * Ed25519 key type. Ed25519 is supported in JDK 15 and later.
+         */
         ED25519
     }
 


### PR DESCRIPTION
Set the release to JDK8 to allow using the package with old JDKs.  It was previously bumped to JDK15 with the addition of Ed25519 of support, but when Ed22519 is not used, JDK release can be left to JDK8.

Fixes #34